### PR TITLE
Implement phase 1 of the Weakpoints mechanic

### DIFF
--- a/Assets/Scripts/Shootable/Shootable.cs
+++ b/Assets/Scripts/Shootable/Shootable.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using System.Collections.Generic;
+
 
 public abstract class Shootable : MonoBehaviour
 {
@@ -12,6 +14,14 @@ public abstract class Shootable : MonoBehaviour
     private int materialIndex;
     private float scaleFactor;
 
+    [System.Serializable]
+    public struct Hitbox
+    {
+        public Collider collider;
+        public float multiplier;
+    }
+
+    public Hitbox[] Hitboxes;
     public bool IsDead => isDead;
     public FurnitureSO FurnitureSO => furnitureSO;
 
@@ -35,12 +45,20 @@ public abstract class Shootable : MonoBehaviour
         meshRenderer.material.color = Color.blue; // Here we just change the material to the dead material for testing purposes, this can be changed to whatever logic to handle death
     }
 
-    public void TakeDamage(int damage)
+    public void TakeDamage(int damage, Collider hitbox)
     {
         if (isDead) return;
-
-        currentHealth -= damage;
-
+        float damage_mult = 1f;
+        foreach (Hitbox hit in Hitboxes)
+        {
+            if (hit.collider == hitbox)
+            {
+                damage_mult = hit.multiplier;
+            }
+        }
+        int final_damage = (int)(damage * damage_mult);
+        currentHealth -= final_damage;
+        print(damage_mult);
         if (currentHealth <= 0) Die();
     }
 

--- a/Assets/Scripts/Shootable/Shootable.cs
+++ b/Assets/Scripts/Shootable/Shootable.cs
@@ -48,7 +48,9 @@ public abstract class Shootable : MonoBehaviour
     public void TakeDamage(int damage, Collider hitbox)
     {
         if (isDead) return;
+
         float damage_mult = 1f;
+
         foreach (Hitbox hit in Hitboxes)
         {
             if (hit.collider == hitbox)
@@ -56,9 +58,11 @@ public abstract class Shootable : MonoBehaviour
                 damage_mult = hit.multiplier;
             }
         }
+
         int final_damage = (int)(damage * damage_mult);
+
         currentHealth -= final_damage;
-        print(damage_mult);
+
         if (currentHealth <= 0) Die();
     }
 

--- a/Assets/Scripts/Weapons/Bullet.cs
+++ b/Assets/Scripts/Weapons/Bullet.cs
@@ -14,7 +14,7 @@ public class Bullet : MonoBehaviour
         Shootable shootableTarget = collision.transform.GetComponentInParent<Shootable>();
         if (shootableTarget != null)
         {
-            shootableTarget.TakeDamage(damage);
+            shootableTarget.TakeDamage(damage, collision.collider);
             //bullet hole
             ContactPoint contact = collision.contacts[0];
             Quaternion rotation = Quaternion.FromToRotation(Vector3.up, contact.normal);


### PR DESCRIPTION
This change will modify specifically Bullet and Shootable.

- A new public serializable struct called Hitbox has been added to Shootable, which contains a Collider called hitbox and a float called multiplier.
- A new public array called Hitboxes has also been implemented to Shootable, which uses this new Hitbox struct so that the hitbox multipliers can be set up in the editor specifically.
- TakeDamage from Shootable has been modified to also require a Collider called hitbox. It now has a float value called damage_multiplier that starts off as 1, but it loops through Hitboxes until it finds a matching Collider to override the damage_multiplier, otherwise it does nothing if the array is blank or can't find a match. It then defines a new int called final_damage that multiplies the damage by the damage_multiplier.
- Consequentially because of the new change in parameter, Bullet has been modified to also use the collision parameter from OnCollisionEnter event to fetch the collider in order to call the TakeDamage function from Shootable. 