### PR TITLE
Implement Limping Mechanic

### DIFF
--- a/Assets/Scripts/Shootable/Shootable.cs
+++ b/Assets/Scripts/Shootable/Shootable.cs
@@ -49,19 +49,19 @@ public abstract class Shootable : MonoBehaviour
     {
         if (isDead) return;
 
-        float damage_mult = 1f;
+        float damageMult = 1f;
 
         foreach (Hitbox hit in Hitboxes)
         {
             if (hit.collider == hitbox)
             {
-                damage_mult = hit.multiplier;
+                damageMult = hit.multiplier;
             }
         }
 
-        int final_damage = (int)(damage * damage_mult);
+        int finalDamage = (int)(damage * damageMult);
 
-        currentHealth -= final_damage;
+        currentHealth -= finalDamage;
 
         if (currentHealth <= 0) Die();
     }

--- a/Assets/Scripts/Shootable/Shootable.cs
+++ b/Assets/Scripts/Shootable/Shootable.cs
@@ -65,6 +65,12 @@ public abstract class Shootable : MonoBehaviour
 
         if (currentHealth <= 0) Die();
     }
+    public int[] GetHealth()
+    {
+        int[] healthStatus = { currentHealth, furnitureSO.maxHealth };
+        return healthStatus;
+    }
+        
 
     public InventoryItem GetInventoryItem()
     {

--- a/Assets/Scripts/Shootable/WanderAI.cs
+++ b/Assets/Scripts/Shootable/WanderAI.cs
@@ -50,7 +50,10 @@ public class WanderAI : MonoBehaviour
 				agent.SetDestination(point);
 		}
 
-		Collider[] hitColliders = Physics.OverlapSphere(transform.position, perceptionRadius);
+        int[] status = shootable.GetHealth(); //fetch currentHealth and maxHealth respectfully
+        agent.speed = shootable.FurnitureSO.speed * (1 - Mathf.Pow(((status[1] - status[0])/status[1]),3)); //multiplies the speed proportionally to a graph of y = 1 - x^3, where x is ((maxHealth - currentHealth) / maxHealth)
+
+        Collider[] hitColliders = Physics.OverlapSphere(transform.position, perceptionRadius);
 
         foreach (Collider hitCollider in hitColliders)
         {


### PR DESCRIPTION
This change will modify specifically Shootable and WanderAI.
- Based on future reference, the casing for Shootable has been fixed to use camel casing.
- Shootable has a new public method called GetHealth, which returns an array of two integers, the first integer being the private integer currentHealth, and the second integer being maxHealth sourced from FurnitureSO.
- WanderAI's Update() method has been expanded upon to include a status integer array obtained from calling GetHealth() from Shootable. Immediately afterwards, the agent speed is set using the speed sourced from FurnitureSO in Shootable, multiplied by a series of operators which resemble a graph formula of y = 1 - x^3, where x is the result of the difference between maxHealth and currentHealth, divided by maxHealth. The formula can be adjusted or discussed accordingly, depending on what result is desired on, with what approximate percentage of health should have a noticeable impact on speed. This current formula is intended to have a noticeable impact of speed at 50% health onwards.