### PR TITLE
Fix random zoom in when reloading

### DIFF
--- a/Assets/Scripts/Weapons/Gun.cs
+++ b/Assets/Scripts/Weapons/Gun.cs
@@ -126,7 +126,8 @@ public class Gun : MonoBehaviour, IEquippable
 
 		// Trigger reload
 		state = GunState.Reloading;
-		ToggleADS(false);
+		if(ads)
+			ToggleADS(false);
 		anim.SetBool("Reload", true);
 		AnimationTrigger("Reload");
 		HuntingUIManager.Instance.ReloadBarAnimation(GunSO.reloadTime);


### PR DESCRIPTION
When the user reloads, the ads is briefly toggled causing a quick and random zoom in. This fixes that by adding a simple boolean check.