### PR TITLE
Fixed prefabs and inventory not saving

### DIFF
--- a/Assets/Prefabs/FurniturePlaceable/Placable_ShadedLamp.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placable_ShadedLamp.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 764f56dde2dbf564a8aaa0ede46f1549, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 764f56dde2dbf564a8aaa0ede46f1549, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 764f56dde2dbf564a8aaa0ede46f1549, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 764f56dde2dbf564a8aaa0ede46f1549, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Arm_Chair_Single.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Arm_Chair_Single.prefab
@@ -51,7 +51,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   canPlaceOnSurface: 0
-  <Mesh>k__BackingField: {fileID: -7511558181221131132, guid: 1e49b884147a5344082ab1ee90eca860, type: 3}
+  <MeshRenderer>k__BackingField: {fileID: 911387565948650238}
+  <MeshFilter>k__BackingField: {fileID: 3116791523061216820}
 --- !u!54 &-231657051590127972
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -231,6 +232,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 7897630587547476802}
   m_SourcePrefab: {fileID: 100100000, guid: 1e49b884147a5344082ab1ee90eca860, type: 3}
+--- !u!23 &911387565948650238 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: 1e49b884147a5344082ab1ee90eca860, type: 3}
+  m_PrefabInstance: {fileID: 1973829565917781626}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1703797006532371243 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 1e49b884147a5344082ab1ee90eca860, type: 3}
@@ -261,5 +267,10 @@ MeshCollider:
 --- !u!4 &2084826832024910225 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 1e49b884147a5344082ab1ee90eca860, type: 3}
+  m_PrefabInstance: {fileID: 1973829565917781626}
+  m_PrefabAsset: {fileID: 0}
+--- !u!33 &3116791523061216820 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: -5754084199372789682, guid: 1e49b884147a5344082ab1ee90eca860, type: 3}
   m_PrefabInstance: {fileID: 1973829565917781626}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Bed.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Bed.prefab
@@ -52,7 +52,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   canPlaceOnSurface: 0
-  <Mesh>k__BackingField: {fileID: -7511558181221131132, guid: ea699233096c09544836fbf927035d34, type: 3}
+  <MeshRenderer>k__BackingField: {fileID: 1740197161819649422}
+  <MeshFilter>k__BackingField: {fileID: 4594405340714877252}
 --- !u!54 &-231657051590127972
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -99,8 +100,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1.9378514, y: 0.3543066, z: 1.4902315}
-  m_Center: {x: -0.8952198, y: 0.15664376, z: -0.00000008940697}
+  m_Size: {x: 2.1009612, y: 0.3543066, z: 2.5022922}
+  m_Center: {x: -0.8136649, y: 0.15664376, z: 0.26749492}
 --- !u!65 &6709149465565957218
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -120,8 +121,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1.4795744, y: 0.4138534, z: 1.5471473}
-  m_Center: {x: -0.6127895, y: 0.5381892, z: 0.0071433783}
+  m_Size: {x: 1.6038218, y: 0.4138534, z: 2.505104}
+  m_Center: {x: -0.55066586, y: 0.5381892, z: 0.25097507}
 --- !u!65 &7107676215796086297
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -141,8 +142,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.5713296, y: 0.3042891, z: 1.5270534}
-  m_Center: {x: -1.6408935, y: 0.48840296, z: -0.003513664}
+  m_Size: {x: 0.5713296, y: 0.3042891, z: 2.3682494}
+  m_Center: {x: -1.6408935, y: 0.48840296, z: 0.2760733}
 --- !u!65 &6754296279492008616
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -162,8 +163,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.40267253, y: 0.1356321, z: 1.4919167}
-  m_Center: {x: -1.5776471, y: 0.7343613, z: 0.0070273876}
+  m_Size: {x: 0.40267253, y: 0.13563204, z: 2.4773283}
+  m_Center: {x: -1.5776471, y: 0.7343613, z: 0.22685677}
 --- !u!65 &4387307260796570101
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -183,8 +184,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.15671444, y: 0.78215134, z: 1.5551631}
-  m_Center: {x: -1.862256, y: 0.7132792, z: 0.0035136938}
+  m_Size: {x: 0.15671444, y: 0.78215134, z: 2.534227}
+  m_Center: {x: -1.862256, y: 0.7132792, z: 0.2368362}
 --- !u!1001 &1146159201404692746
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -196,6 +197,18 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: ea699233096c09544836fbf927035d34, type: 3}
       propertyPath: m_RootOrder
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea699233096c09544836fbf927035d34, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea699233096c09544836fbf927035d34, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ea699233096c09544836fbf927035d34, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ea699233096c09544836fbf927035d34, type: 3}
       propertyPath: m_LocalPosition.x
@@ -279,5 +292,15 @@ MeshCollider:
 --- !u!4 &607212743534628577 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ea699233096c09544836fbf927035d34, type: 3}
+  m_PrefabInstance: {fileID: 1146159201404692746}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &1740197161819649422 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: ea699233096c09544836fbf927035d34, type: 3}
+  m_PrefabInstance: {fileID: 1146159201404692746}
+  m_PrefabAsset: {fileID: 0}
+--- !u!33 &4594405340714877252 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: -5754084199372789682, guid: ea699233096c09544836fbf927035d34, type: 3}
   m_PrefabInstance: {fileID: 1146159201404692746}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Blender.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Blender.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 40c8e2e5ca893b342ad1da66184a7fcc, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 40c8e2e5ca893b342ad1da66184a7fcc, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 40c8e2e5ca893b342ad1da66184a7fcc, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 40c8e2e5ca893b342ad1da66184a7fcc, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_CoffeeMaker.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_CoffeeMaker.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 7fe4b582cbf4a5f488685c61b46bcec4, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7fe4b582cbf4a5f488685c61b46bcec4, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7fe4b582cbf4a5f488685c61b46bcec4, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7fe4b582cbf4a5f488685c61b46bcec4, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Couch_Double.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Couch_Double.prefab
@@ -177,6 +177,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 394c072e4d014be46b72eed5883ff0bd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 394c072e4d014be46b72eed5883ff0bd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 394c072e4d014be46b72eed5883ff0bd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 394c072e4d014be46b72eed5883ff0bd, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Couch_Single.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Couch_Single.prefab
@@ -177,6 +177,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 581b65132bf09cc44874fbb94198371e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 581b65132bf09cc44874fbb94198371e, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 581b65132bf09cc44874fbb94198371e, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 581b65132bf09cc44874fbb94198371e, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Cup.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Cup.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 789bf99687679bf4299f645af945ad91, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 789bf99687679bf4299f645af945ad91, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 789bf99687679bf4299f645af945ad91, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 789bf99687679bf4299f645af945ad91, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Dresser_Small.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Dresser_Small.prefab
@@ -178,6 +178,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 2ed8493930e2d954e8e89dc84be8136c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2ed8493930e2d954e8e89dc84be8136c, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2ed8493930e2d954e8e89dc84be8136c, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2ed8493930e2d954e8e89dc84be8136c, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Dryer.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Dryer.prefab
@@ -178,6 +178,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5dc46d215fc9b55429e324675df9956f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dc46d215fc9b55429e324675df9956f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dc46d215fc9b55429e324675df9956f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dc46d215fc9b55429e324675df9956f, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Dumbbell_Heavy.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Dumbbell_Heavy.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ff738d293233528478447791ba68d085, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff738d293233528478447791ba68d085, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff738d293233528478447791ba68d085, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff738d293233528478447791ba68d085, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Dumbbell_Light.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Dumbbell_Light.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: eaecdab261b8eaf47bcdeafecd47b10d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: eaecdab261b8eaf47bcdeafecd47b10d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: eaecdab261b8eaf47bcdeafecd47b10d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: eaecdab261b8eaf47bcdeafecd47b10d, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge.prefab
@@ -49,7 +49,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   canPlaceOnSurface: 0
-  <Mesh>k__BackingField: {fileID: -7511558181221131132, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+  <MeshRenderer>k__BackingField: {fileID: 3773700184873862930}
+  <MeshFilter>k__BackingField: {fileID: 1421474036754117592}
 --- !u!54 &8568587000754051143
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -133,6 +134,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}
@@ -184,6 +197,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 5777921137257818132}
   m_SourcePrefab: {fileID: 100100000, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+--- !u!33 &1421474036754117592 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: -5754084199372789682, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+  m_PrefabInstance: {fileID: 2566899998400256918}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2600209277316791421 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
@@ -216,3 +234,8 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 3082250236548730855, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+--- !u!23 &3773700184873862930 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: 0077cf35555164b49a751fcbfe247ec2, type: 3}
+  m_PrefabInstance: {fileID: 2566899998400256918}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_Double_Door 1.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_Double_Door 1.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 2c0f214635240df4c8c72fc783693ffc, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2c0f214635240df4c8c72fc783693ffc, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2c0f214635240df4c8c72fc783693ffc, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 2c0f214635240df4c8c72fc783693ffc, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_Freezer_Single_Door.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_Freezer_Single_Door.prefab
@@ -134,6 +134,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 732e45f79dc444c439122f14a9ce6d6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 732e45f79dc444c439122f14a9ce6d6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 732e45f79dc444c439122f14a9ce6d6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 732e45f79dc444c439122f14a9ce6d6f, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_Rounded.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_Rounded.prefab
@@ -134,6 +134,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: acb161e3a8dec6747b67f186b7dc116c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: acb161e3a8dec6747b67f186b7dc116c, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: acb161e3a8dec6747b67f186b7dc116c, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: acb161e3a8dec6747b67f186b7dc116c, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_SingleDoor 1.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Fridge_SingleDoor 1.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: a3ba519f39a1de742ad8f74fafe70b46, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a3ba519f39a1de742ad8f74fafe70b46, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a3ba519f39a1de742ad8f74fafe70b46, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a3ba519f39a1de742ad8f74fafe70b46, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Futon.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Futon.prefab
@@ -155,6 +155,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0f4be89721d1f2a498c8099350cc898b, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0f4be89721d1f2a498c8099350cc898b, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0f4be89721d1f2a498c8099350cc898b, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0f4be89721d1f2a498c8099350cc898b, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Ketchup.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Ketchup.prefab
@@ -48,8 +48,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   canPlaceOnSurface: 1
-  <MeshRenderer>k__BackingField: {fileID: 0}
-  <MeshFilter>k__BackingField: {fileID: 0}
+  <MeshRenderer>k__BackingField: {fileID: 8672052860032277696}
+  <MeshFilter>k__BackingField: {fileID: 6898852073949014026}
 --- !u!54 &8568587000754051143
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: e5187187fda714c40a46908ebd12822d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e5187187fda714c40a46908ebd12822d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e5187187fda714c40a46908ebd12822d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e5187187fda714c40a46908ebd12822d, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}
@@ -162,6 +174,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1593448458654584834}
   m_SourcePrefab: {fileID: 100100000, guid: e5187187fda714c40a46908ebd12822d, type: 3}
+--- !u!33 &6898852073949014026 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: -5754084199372789682, guid: e5187187fda714c40a46908ebd12822d, type: 3}
+  m_PrefabInstance: {fileID: 8041396491014684740}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &7158944745682500885 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: e5187187fda714c40a46908ebd12822d, type: 3}
@@ -192,5 +209,10 @@ MeshCollider:
 --- !u!4 &7499195957297129391 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: e5187187fda714c40a46908ebd12822d, type: 3}
+  m_PrefabInstance: {fileID: 8041396491014684740}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &8672052860032277696 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: e5187187fda714c40a46908ebd12822d, type: 3}
   m_PrefabInstance: {fileID: 8041396491014684740}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Kitchen_Chair.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Kitchen_Chair.prefab
@@ -155,6 +155,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: e8ea8c9f86334bf4d80519304a2339f9, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e8ea8c9f86334bf4d80519304a2339f9, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e8ea8c9f86334bf4d80519304a2339f9, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e8ea8c9f86334bf4d80519304a2339f9, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Lamp.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Lamp.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 398acf82adbbd354db8072933b6099eb, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 398acf82adbbd354db8072933b6099eb, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 398acf82adbbd354db8072933b6099eb, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 398acf82adbbd354db8072933b6099eb, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Lamp_Short.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Lamp_Short.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 44c52e5eae9b35e4c9269b993996ac53, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 44c52e5eae9b35e4c9269b993996ac53, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 44c52e5eae9b35e4c9269b993996ac53, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 44c52e5eae9b35e4c9269b993996ac53, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Lamp_Tall.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Lamp_Tall.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: e78d980d5b51056428682e11b1671511, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e78d980d5b51056428682e11b1671511, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e78d980d5b51056428682e11b1671511, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e78d980d5b51056428682e11b1671511, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Laptop.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Laptop.prefab
@@ -133,6 +133,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b8d833a3d9411984da74c0ed962bf814, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8d833a3d9411984da74c0ed962bf814, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8d833a3d9411984da74c0ed962bf814, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8d833a3d9411984da74c0ed962bf814, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Microwave.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Microwave.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: df441881ab6e5484dab8faed4589f2b0, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: df441881ab6e5484dab8faed4589f2b0, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: df441881ab6e5484dab8faed4589f2b0, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: df441881ab6e5484dab8faed4589f2b0, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Picnic Table.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Picnic Table.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4931377033494305184}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.30394503, y: 1.667, z: 1.1806633}
+  m_LocalPosition: {x: 0.636, y: 1.345, z: 1.33}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -64,8 +64,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 2.8384328, y: 0.036957145, z: 1.5056391}
-  m_Center: {x: -0.29908824, y: -0.48152143, z: -1.4516757}
+  m_Size: {x: 2.036059, y: 0.036957145, z: 1.0349998}
+  m_Center: {x: -0.6295757, y: -0.48152143, z: -1.3365858}
 --- !u!1 &6687055942871566689
 GameObject:
   m_ObjectHideFlags: 0
@@ -163,8 +163,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 2.8729262, y: 1.1727426, z: 1.5341177}
-  m_Center: {x: -0.004148543, y: 0.58571124, z: -0.27585602}
+  m_Size: {x: 2.0655184, y: 1.1727426, z: 1.0495512}
+  m_Center: {x: -0.013598919, y: 0.58571124, z: -0.033572853}
 --- !u!1001 &4855963422371801498
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -179,19 +179,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 22694a58f82aa7141a55f136dec7ad44, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.12980422
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 22694a58f82aa7141a55f136dec7ad44, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.14084782
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 22694a58f82aa7141a55f136dec7ad44, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.14713849
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 22694a58f82aa7141a55f136dec7ad44, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.392
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 22694a58f82aa7141a55f136dec7ad44, type: 3}
       propertyPath: m_LocalPosition.y
@@ -199,7 +199,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 22694a58f82aa7141a55f136dec7ad44, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.077
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 22694a58f82aa7141a55f136dec7ad44, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Plushie_Bear.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Plushie_Bear.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 4bc16cdc069d148328d7fb099fc67719, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4bc16cdc069d148328d7fb099fc67719, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4bc16cdc069d148328d7fb099fc67719, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4bc16cdc069d148328d7fb099fc67719, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Potted_Plant.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Potted_Plant.prefab
@@ -111,6 +111,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: da8ee85da77dae547b3bc0322b9636f5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da8ee85da77dae547b3bc0322b9636f5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da8ee85da77dae547b3bc0322b9636f5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: da8ee85da77dae547b3bc0322b9636f5, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0
       objectReference: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_RectRug.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_RectRug.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 8987057357527107057}
   - component: {fileID: 1539234630903234798}
   - component: {fileID: 3045520997839687616}
-  - component: {fileID: 98455651165504017}
+  - component: {fileID: 2275241376230740707}
   m_Layer: 6
   m_Name: Placeable_RectRug
   m_TagString: Untagged
@@ -77,7 +77,7 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &98455651165504017
+--- !u!65 &2275241376230740707
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -92,12 +92,12 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 7.9319963, y: 0.049999997, z: 4.7664995}
-  m_Center: {x: 3.938724, y: 0.029028699, z: 2.2858095}
+  m_Size: {x: 0.078377694, y: 0.0017096035, z: 0.04766081}
+  m_Center: {x: 0.000006530434, y: 0.00014637143, z: 0.0002548732}
 --- !u!1001 &897116061941146916
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -109,6 +109,18 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: e15f2f084db13af4eb1ca63cc9535b2d, type: 3}
       propertyPath: m_RootOrder
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e15f2f084db13af4eb1ca63cc9535b2d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e15f2f084db13af4eb1ca63cc9535b2d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: e15f2f084db13af4eb1ca63cc9535b2d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: e15f2f084db13af4eb1ca63cc9535b2d, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Sink_Round.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Sink_Round.prefab
@@ -134,15 +134,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 19ca9b9b7c6af01418141c429f3c706f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.608
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 19ca9b9b7c6af01418141c429f3c706f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.055
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 19ca9b9b7c6af01418141c429f3c706f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.04
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 19ca9b9b7c6af01418141c429f3c706f, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Small Dresser.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Small Dresser.prefab
@@ -179,7 +179,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 57f36821fbacc444a83ba13036d24ba6, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0.614
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 57f36821fbacc444a83ba13036d24ba6, type: 3}
       propertyPath: m_LocalPosition.y
@@ -187,7 +187,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 57f36821fbacc444a83ba13036d24ba6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 0.375
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 57f36821fbacc444a83ba13036d24ba6, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_SmallChair.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_SmallChair.prefab
@@ -142,7 +142,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 7f284dac90fc6534ba96db59faa091b5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -0.123
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 7f284dac90fc6534ba96db59faa091b5, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Sofa.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Sofa.prefab
@@ -52,7 +52,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   canPlaceOnSurface: 0
-  <Mesh>k__BackingField: {fileID: -7511558181221131132, guid: c0059db36d5ba20478429fcd0e6754e6, type: 3}
+  <MeshRenderer>k__BackingField: {fileID: 312708641932931683}
+  <MeshFilter>k__BackingField: {fileID: 2572120070378194601}
 --- !u!54 &-231657051590127972
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -250,6 +251,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 4349288271960150526}
   m_SourcePrefab: {fileID: 100100000, guid: c0059db36d5ba20478429fcd0e6754e6, type: 3}
+--- !u!23 &312708641932931683 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: c0059db36d5ba20478429fcd0e6754e6, type: 3}
+  m_PrefabInstance: {fileID: 1411706391126208231}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1449554377819064588 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c0059db36d5ba20478429fcd0e6754e6, type: 3}
@@ -282,3 +288,8 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -4650390976156102637, guid: c0059db36d5ba20478429fcd0e6754e6, type: 3}
+--- !u!33 &2572120070378194601 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: -5754084199372789682, guid: c0059db36d5ba20478429fcd0e6754e6, type: 3}
+  m_PrefabInstance: {fileID: 1411706391126208231}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Stove.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Stove.prefab
@@ -112,7 +112,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 7fc6e1433dfb4e94ebb532223c518414, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0.454
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 7fc6e1433dfb4e94ebb532223c518414, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Table.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Table.prefab
@@ -48,7 +48,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   canPlaceOnSurface: 0
-  <Mesh>k__BackingField: {fileID: 3082429393603250123}
+  <MeshRenderer>k__BackingField: {fileID: 3082429393603250123}
+  <MeshFilter>k__BackingField: {fileID: 946330392160449281}
 --- !u!65 &8127022634081417968
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -149,6 +150,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fb603754ef13fc442b8fe9b9df50ab57, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: fb603754ef13fc442b8fe9b9df50ab57, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: fb603754ef13fc442b8fe9b9df50ab57, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: fb603754ef13fc442b8fe9b9df50ab57, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.00216006
       objectReference: {fileID: 0}
@@ -200,6 +213,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 7454258119363628894}
   m_SourcePrefab: {fileID: 100100000, guid: fb603754ef13fc442b8fe9b9df50ab57, type: 3}
+--- !u!33 &946330392160449281 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: -5754084199372789682, guid: fb603754ef13fc442b8fe9b9df50ab57, type: 3}
+  m_PrefabInstance: {fileID: 4397598539175385935}
+  m_PrefabAsset: {fileID: 0}
 --- !u!23 &3082429393603250123 stripped
 MeshRenderer:
   m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: fb603754ef13fc442b8fe9b9df50ab57, type: 3}

--- a/Assets/Prefabs/FurniturePlaceable/Placeable_Toilet.prefab
+++ b/Assets/Prefabs/FurniturePlaceable/Placeable_Toilet.prefab
@@ -81,8 +81,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1.930581, y: 2.861616, z: 2.7249758}
-  m_Center: {x: -0.048425972, y: 0.93080795, z: 0.2762425}
+  m_Size: {x: 0.77488136, y: 1.1769552, z: 1.1956155}
+  m_Center: {x: -1.0559403, y: 0.15301764, z: 1.472217}
 --- !u!114 &-2862497397986654166
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -109,6 +109,18 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 753907fc99d210f428bbfcfb89316f37, type: 3}
       propertyPath: m_RootOrder
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 753907fc99d210f428bbfcfb89316f37, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 753907fc99d210f428bbfcfb89316f37, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 753907fc99d210f428bbfcfb89316f37, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 753907fc99d210f428bbfcfb89316f37, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Managers/DataPersistenceManager.prefab
+++ b/Assets/Prefabs/Managers/DataPersistenceManager.prefab
@@ -45,21 +45,49 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allFurnitureSOs:
+  - {fileID: 11400000, guid: 30ad2a97907a2b24ab3a83f591c80069, type: 2}
+  - {fileID: 11400000, guid: 5f7faa6b0f6129149ad93c641b90fa95, type: 2}
+  - {fileID: 11400000, guid: 01e6a66a70302804c9a247b25d61258e, type: 2}
   - {fileID: 11400000, guid: 857f2c0c040ac284990a110f3906f1f2, type: 2}
   - {fileID: 11400000, guid: 0cdac4930d953e543a59711da068dbcf, type: 2}
+  - {fileID: 11400000, guid: 30d64d377475496439a7c724926c85cb, type: 2}
+  - {fileID: 11400000, guid: 857f2c0c040ac284990a110f3906f1f2, type: 2}
+  - {fileID: 11400000, guid: 0cdac4930d953e543a59711da068dbcf, type: 2}
+  - {fileID: 11400000, guid: 30d64d377475496439a7c724926c85cb, type: 2}
   - {fileID: 11400000, guid: ee9aa1c04b07097418393da139fee3ac, type: 2}
   - {fileID: 11400000, guid: 390014d96b7a124489f5476ed23af37c, type: 2}
   - {fileID: 11400000, guid: 2ff3726ac4d336548bbd77a204a31a20, type: 2}
+  - {fileID: 11400000, guid: 48e0cfe3a938b304fa36b6d7b558345c, type: 2}
+  - {fileID: 11400000, guid: e58311a1038eacc40bff5a80bc216383, type: 2}
+  - {fileID: 11400000, guid: cf850a75cacd18e46af13506a214b441, type: 2}
+  - {fileID: 11400000, guid: aadb05b628fc0c5448afc696d5e8a8d5, type: 2}
+  - {fileID: 11400000, guid: 9cdebf1c3a02803429f6ef691745750d, type: 2}
   - {fileID: 11400000, guid: ae55ba0707fa4ca409e3ff2ae1e3d041, type: 2}
-  - {fileID: 11400000, guid: 9ddad2494a1833c4b93befdaff372f47, type: 2}
+  - {fileID: 11400000, guid: 88d751b73f794ac43bca2a54c1f46a95, type: 2}
+  - {fileID: 11400000, guid: 6014bef3271af5946a873708a73872d2, type: 2}
+  - {fileID: 11400000, guid: cf8b701937832ce48b59fddc077e5ffe, type: 2}
+  - {fileID: 11400000, guid: 0f3f4a610d8be3a40a3daf0d441bdc22, type: 2}
   - {fileID: 11400000, guid: 2d9675b2fd54ef344b9c7e4ceed87213, type: 2}
+  - {fileID: 11400000, guid: a4ba31d18bc418242b6d5754ddce66a6, type: 2}
+  - {fileID: 11400000, guid: cede0f77b25759b42ab608df35e8ba5f, type: 2}
+  - {fileID: 11400000, guid: 1bb06885978b3ab4e9f8a3083d3cc692, type: 2}
+  - {fileID: 11400000, guid: 49adc027f79b600469e24c2b6122e68a, type: 2}
+  - {fileID: 11400000, guid: 00b22e0837bbc2d439935c0c17d21a03, type: 2}
+  - {fileID: 11400000, guid: 119af22826c22c147b12a3be3fff2e18, type: 2}
+  - {fileID: 11400000, guid: 797cbaed86280064a861c638b3a3c965, type: 2}
+  - {fileID: 11400000, guid: c73e0940ec7598d43927ba7a4614bf8b, type: 2}
   - {fileID: 11400000, guid: 52d1dfc4d1fd73a47ba04b980dd7ec55, type: 2}
+  - {fileID: 11400000, guid: 599b460a879b08f4fb548c0fa447256d, type: 2}
   - {fileID: 11400000, guid: a23d6fea2a74c67479c79fb36c6d8859, type: 2}
+  - {fileID: 11400000, guid: f302573cde82c2849891abfc25593b49, type: 2}
+  - {fileID: 11400000, guid: cc861b3833482484da079aaeecda21f9, type: 2}
+  - {fileID: 11400000, guid: 6a7bca614665ada4d85f90bd3e2001d9, type: 2}
   - {fileID: 11400000, guid: cd559f755261cca438240d2e52738194, type: 2}
+  - {fileID: 11400000, guid: 55911cc1ae1705e43b4ff2ffc9f368d5, type: 2}
+  - {fileID: 11400000, guid: 861e66ed8142290408147089ab8a096f, type: 2}
   - {fileID: 11400000, guid: f969dfeb6f33ee1429039bc213cc923f, type: 2}
   - {fileID: 11400000, guid: 4c07085b656abdf44b9774af59f1b4ab, type: 2}
   - {fileID: 11400000, guid: 1dcca73881634e345b92d7a7b74d5654, type: 2}
-  - {fileID: 11400000, guid: ee7a3cc002bc546db9fdc640e2d13210, type: 2}
   - {fileID: 11400000, guid: ed2eda5cbd2d1fa4e85cc8ce1d6a522d, type: 2}
   - {fileID: 11400000, guid: d8ba5da86a44f4045b4e574ac544d79b, type: 2}
   - {fileID: 11400000, guid: cbd97b12ef5a0044ebb329bf329499a6, type: 2}
@@ -69,37 +97,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5b12c4e150374a54e91cb0488d88c288, type: 2}
   - {fileID: 11400000, guid: 5a55630e77da96046bad62b589c6be9a, type: 2}
   - {fileID: 11400000, guid: 3b065a9e1b7ca014a8381bf682dff59f, type: 2}
-  - {fileID: 11400000, guid: cdedef21e3f841b428cb71cb08e6a8db, type: 2}
   - {fileID: 11400000, guid: d51a9e0a14d1de940b50bfdec61da34c, type: 2}
   - {fileID: 11400000, guid: 2fa2974c4cdc35549a10d4871a8e3a66, type: 2}
-  - {fileID: 11400000, guid: a4ba31d18bc418242b6d5754ddce66a6, type: 2}
-  - {fileID: 11400000, guid: 1bb06885978b3ab4e9f8a3083d3cc692, type: 2}
   - {fileID: 11400000, guid: 53800333325b795459313801fa2e6fa7, type: 2}
-  - {fileID: 11400000, guid: 49adc027f79b600469e24c2b6122e68a, type: 2}
-  - {fileID: 11400000, guid: cede0f77b25759b42ab608df35e8ba5f, type: 2}
-  - {fileID: 11400000, guid: 30d64d377475496439a7c724926c85cb, type: 2}
-  - {fileID: 11400000, guid: cc861b3833482484da079aaeecda21f9, type: 2}
-  - {fileID: 11400000, guid: f302573cde82c2849891abfc25593b49, type: 2}
-  - {fileID: 11400000, guid: 6014bef3271af5946a873708a73872d2, type: 2}
-  - {fileID: 11400000, guid: e58311a1038eacc40bff5a80bc216383, type: 2}
-  - {fileID: 11400000, guid: 48e0cfe3a938b304fa36b6d7b558345c, type: 2}
-  - {fileID: 11400000, guid: 119af22826c22c147b12a3be3fff2e18, type: 2}
-  - {fileID: 11400000, guid: 5f7faa6b0f6129149ad93c641b90fa95, type: 2}
-  - {fileID: 11400000, guid: 88d751b73f794ac43bca2a54c1f46a95, type: 2}
-  - {fileID: 11400000, guid: 861e66ed8142290408147089ab8a096f, type: 2}
-  - {fileID: 11400000, guid: 01e6a66a70302804c9a247b25d61258e, type: 2}
-  - {fileID: 11400000, guid: cf850a75cacd18e46af13506a214b441, type: 2}
-  - {fileID: 11400000, guid: aadb05b628fc0c5448afc696d5e8a8d5, type: 2}
-  - {fileID: 11400000, guid: 9cdebf1c3a02803429f6ef691745750d, type: 2}
-  - {fileID: 11400000, guid: cf8b701937832ce48b59fddc077e5ffe, type: 2}
-  - {fileID: 11400000, guid: 0f3f4a610d8be3a40a3daf0d441bdc22, type: 2}
-  - {fileID: 11400000, guid: 00b22e0837bbc2d439935c0c17d21a03, type: 2}
-  - {fileID: 11400000, guid: 797cbaed86280064a861c638b3a3c965, type: 2}
-  - {fileID: 11400000, guid: c73e0940ec7598d43927ba7a4614bf8b, type: 2}
-  - {fileID: 11400000, guid: 599b460a879b08f4fb548c0fa447256d, type: 2}
-  - {fileID: 11400000, guid: 30ad2a97907a2b24ab3a83f591c80069, type: 2}
-  - {fileID: 11400000, guid: 55911cc1ae1705e43b4ff2ffc9f368d5, type: 2}
-  - {fileID: 11400000, guid: 6a7bca614665ada4d85f90bd3e2001d9, type: 2}
   allGunSOs:
   - {fileID: 11400000, guid: 260cd78f5b7281843b0c646b1f74255c, type: 2}
   - {fileID: 11400000, guid: 32118748925db9a45a9281c1d16cd3f7, type: 2}

--- a/Assets/Scripts/Data Persistence/GameData.cs
+++ b/Assets/Scripts/Data Persistence/GameData.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 public class GameData
 {
     public List<SaveDataFurniture> storedFurniture;
+    public List<SaveDataFurniture> huntingInventoryFurniture;
     public List<SaveDataPlacedFurniture> placedFurniture;
     public List<SaveDataGun> gunSaveData;
     public int currency;
@@ -13,6 +14,7 @@ public class GameData
     {
         storedFurniture = new();
         placedFurniture = new();
+        huntingInventoryFurniture= new();
         gunSaveData = new();
         currency = 0;
     }

--- a/Assets/Scripts/Managers/DataPersistenceManager.cs
+++ b/Assets/Scripts/Managers/DataPersistenceManager.cs
@@ -34,7 +34,6 @@ public class DataPersistenceManager : Singleton<DataPersistenceManager>
     private void OnDisable() 
     {
         SceneManager.sceneLoaded -= OnSceneLoaded;
-        SceneManager.sceneUnloaded -= OnSceneUnloaded;
     }
 
     private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
@@ -53,7 +52,10 @@ public class DataPersistenceManager : Singleton<DataPersistenceManager>
         SaveGame();
     }
 
-	private List<IDataPersistence> FindAllDataPersistenceObjects() => new(FindObjectsOfType<MonoBehaviour>().OfType<IDataPersistence>());
+    private List<IDataPersistence> FindAllDataPersistenceObjects() 
+    {
+        return new(FindObjectsOfType<MonoBehaviour>().OfType<IDataPersistence>()); 
+    }
 
 	public void NewGame()
     {
@@ -85,6 +87,7 @@ public class DataPersistenceManager : Singleton<DataPersistenceManager>
         }
 
         fileDataHandler.Save(gameData);
+        SceneManager.sceneUnloaded -= OnSceneUnloaded;
     }
 
     public Placeable GetPlaceablePrefabById(string id)

--- a/Assets/Scripts/Managers/DataPersistenceManager.cs.meta
+++ b/Assets/Scripts/Managers/DataPersistenceManager.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -80
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Managers/HuntingManager.cs
+++ b/Assets/Scripts/Managers/HuntingManager.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
-public class HuntingManager : Singleton<HuntingManager>
+public class HuntingManager : Singleton<HuntingManager>, IDataPersistence
 {
 	[SerializeField] private int maxHealth;
 	[SerializeField] private GameObject gameOverUI;
@@ -82,4 +82,14 @@ public class HuntingManager : Singleton<HuntingManager>
 		GameManager.Instance.HideCursor();
 		SceneManager.LoadScene(1);
 	}
+
+    public void LoadData(GameData data)
+    {
+		HuntingInventory.Furniture = data.huntingInventoryFurniture;
+    }
+
+    public void SaveData(GameData data)
+    {
+		data.huntingInventoryFurniture = HuntingInventory.Furniture;
+    }
 }

--- a/Assets/Scripts/Managers/InventoryUIManager.cs
+++ b/Assets/Scripts/Managers/InventoryUIManager.cs
@@ -36,7 +36,7 @@ public class InventoryUIManager : Singleton<InventoryUIManager>
 
     private FurnitureType selectedTab;
     private (FurnitureSO so, SaveDataFurniture inventoryItem)? selectedFurniture;
-    private List<SaveDataFurniture> furnitureInventory;
+    private FurnitureInventory furnitureInventory;
 
     public (FurnitureSO so, SaveDataFurniture inventoryItem)? SelectedFurniture 
     {
@@ -81,7 +81,7 @@ public class InventoryUIManager : Singleton<InventoryUIManager>
 
     private void Start()
     {
-        furnitureInventory = HuntingManager.Instance != null ? HuntingManager.Instance.HuntingInventory.Furniture : GameManager.Instance.PermanentInventory.Furniture;
+        furnitureInventory = HuntingManager.Instance != null ? HuntingManager.Instance.HuntingInventory : GameManager.Instance.PermanentInventory;
         SetTab(0);
     }
 
@@ -90,7 +90,7 @@ public class InventoryUIManager : Singleton<InventoryUIManager>
         foreach (Transform child in furnitureItemContainer.transform)
             Destroy(child.gameObject);
 
-        foreach (SaveDataFurniture savedFurniture in furnitureInventory)
+        foreach (SaveDataFurniture savedFurniture in furnitureInventory.Furniture)
         {
             FurnitureSO savedFurnitureSO = DataPersistenceManager.Instance.AllFurnitureSO.Find(f => f.id == savedFurniture.id);
             if (savedFurnitureSO != null && savedFurnitureSO.type == selectedTab)
@@ -155,7 +155,7 @@ public class InventoryUIManager : Singleton<InventoryUIManager>
     // referenced in discard button in inventory UI
     public void DiscardSelectedFurniture()
     {
-        furnitureInventory.Remove(selectedFurniture.Value.inventoryItem);
+        furnitureInventory.RemoveItem(selectedFurniture.Value.inventoryItem);
         SelectedFurniture = null;
         RedrawInventoryItems();
     }

--- a/Assets/Scripts/Others/FurnitureInventory.cs
+++ b/Assets/Scripts/Others/FurnitureInventory.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 public class FurnitureInventory
 {
-	private const int maxInventorySize = 10; // Set the maximum inventory size to 10
+	private const int maxInventorySize = 1000; // Set the maximum inventory size to 10
 
 	public List<SaveDataFurniture> Furniture { get; set; }
 


### PR DESCRIPTION
Some placeable prefabs were throwing null ref errors because the mesh field wasn't assigned in the inspector and some of the models were scaled to 100.

Fixed hunting inventory not being saved when entering to house, and permanent inventory not saved when exiting scene.