### PR TITLE
Fixed Charge and Slam Behaviour Damage

### DIFF
--- a/Assets/Scriptable Objects/FurnitureBehaviours/Charge Behaviour.asset
+++ b/Assets/Scriptable Objects/FurnitureBehaviours/Charge Behaviour.asset
@@ -12,8 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea1c5b1fad2360a4992383b37d37ef6f, type: 3}
   m_Name: Charge Behaviour
   m_EditorClassIdentifier: 
-  damage: 10
+  damage: 1
   chargeDelay: 2
-  chargeRange: 3
+  turnRange: 3
   horizontalKnockbackMultiplier: 0.1
   verticalKnockback: 4
+  turningSpeed: 5
+  maxAngle: 240

--- a/Assets/Scripts/Scriptable Objects/Behaviors/ChargeBehaviour.cs
+++ b/Assets/Scripts/Scriptable Objects/Behaviors/ChargeBehaviour.cs
@@ -33,7 +33,7 @@ public class ChargeBehaviour : AIBehaviour
                 foreach (Collider hitCollider in hitColliders)
                 {
                     // If the player manages to collide with the furniture, deal damage and apply knockback! Make sure this only happens once per charge.
-                    Player? player = hitCollider.GetComponentInParent<Player>();
+                    Player player = hitCollider.GetComponentInParent<Player>();
                     if (player != null)
                     {
                         HuntingManager.Instance.DealDamageToPlayer(damage);

--- a/Assets/Scripts/Scriptable Objects/Behaviors/ChargeBehaviour.cs
+++ b/Assets/Scripts/Scriptable Objects/Behaviors/ChargeBehaviour.cs
@@ -4,7 +4,7 @@ using UnityEngine.AI;
 [CreateAssetMenu(fileName = "Charge Behaviour", menuName = "Behaviours/Charge")]
 public class ChargeBehaviour : AIBehaviour
 {
-    [SerializeField] private int damage = 10; // Damage per collision
+    [SerializeField] private int damage = 1; // Damage per collision
     [SerializeField] private float chargeDelay = 2f; // Seconds per charge
     [SerializeField] private float turnRange = 3f; // This is one of the parameters used to cancel a charge early; if the player has gone too far away from the furniture it will stop and turn.
     [SerializeField] private float horizontalKnockbackMultiplier = 0.1f; // Determines how much the horizontal knockback is multiplied. The multiplier should be small to prevent excessive flinging.
@@ -33,7 +33,8 @@ public class ChargeBehaviour : AIBehaviour
                 foreach (Collider hitCollider in hitColliders)
                 {
                     // If the player manages to collide with the furniture, deal damage and apply knockback! Make sure this only happens once per charge.
-                    if (hitCollider.transform.parent.TryGetComponent<Player>(out Player player))
+                    Player? player = hitCollider.GetComponentInParent<Player>();
+                    if (player != null)
                     {
                         HuntingManager.Instance.DealDamageToPlayer(damage);
                         hitPlayer = true;

--- a/Assets/Scripts/Scriptable Objects/Behaviors/SlamBehaviour.cs
+++ b/Assets/Scripts/Scriptable Objects/Behaviors/SlamBehaviour.cs
@@ -30,7 +30,7 @@ public class SlamBehaviour : AIBehaviour
                 Collider[] hitColliders = Physics.OverlapSphere(knowledge.AITransform.position, radius);
                 foreach (Collider hitCollider in hitColliders)
                 {
-                    Player? player = hitCollider.GetComponentInParent<Player>();
+                    Player player = hitCollider.GetComponentInParent<Player>();
                     if (player != null)
                     {
                         HuntingManager.Instance.DealDamageToPlayer(damage);

--- a/Assets/Scripts/Scriptable Objects/Behaviors/SlamBehaviour.cs
+++ b/Assets/Scripts/Scriptable Objects/Behaviors/SlamBehaviour.cs
@@ -27,14 +27,11 @@ public class SlamBehaviour : AIBehaviour
             knowledge.AITransform.position = Parabola(startPosition, endPosition, Mathf.Sqrt(distance / range) * range, jumpTime);
             if (jumpTime >= 1f)
             {
-                int playerLayer = 9;
-                int layerMask = 1 << playerLayer;
-                layerMask = ~layerMask;
-                Collider[] hitColliders = new Collider[10];
-                int colliderCount = Physics.OverlapSphereNonAlloc(knowledge.AITransform.position, radius, hitColliders, layerMask, QueryTriggerInteraction.Collide);
-                for (int i = 0; i < colliderCount; i++)
+                Collider[] hitColliders = Physics.OverlapSphere(knowledge.AITransform.position, radius);
+                foreach (Collider hitCollider in hitColliders)
                 {
-                    if (hitColliders[i].CompareTag("Player"))
+                    Player? player = hitCollider.GetComponentInParent<Player>();
+                    if (player != null)
                     {
                         HuntingManager.Instance.DealDamageToPlayer(damage);
                         break;


### PR DESCRIPTION
Removed some portions of code that were supposed to optimize it, which only turned out to break it later on. Fixed the charge behavior so that it only deals 1 damage instead of one-shotting the player, and adjusted the method so that no errors pop up. Slam Behaviour also applies this, minus the variable and knockback. The previous optimization has been removed since it doesn't look like it ever collides with the player.