### PR TITLE
Initial fix to destroying furniture by interacting with door

### DIFF
--- a/Assets/Scripts/Others/Door.cs
+++ b/Assets/Scripts/Others/Door.cs
@@ -9,7 +9,7 @@ public class Door : MonoBehaviour, IInteractable
 	{
 		if (HuntingManager.Instance)
 			HuntingManager.Instance.RespawnInHouse();
-		else if (HouseManager.Instance)
+		else if (!HouseManager.Instance.HoldingPlaceable)
 			HouseManager.Instance.LoadHuntingScene();
     }
 }


### PR DESCRIPTION
Door.cs
_Changed the condition to load the loading scene to not holding a placeable object